### PR TITLE
Fix iOS unknown key issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-background-mode-fixes",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "Prevent apps from going to sleep in background.",
   "cordova": {
     "id": "cordova-plugin-background-mode-fixes",

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="cordova-plugin-background-mode-fixes"
-        version="0.7.5">
+        version="0.7.6">
 
     <name>BackgroundMode</name>
 

--- a/src/ios/APPBackgroundMode.m
+++ b/src/ios/APPBackgroundMode.m
@@ -241,7 +241,7 @@ NSString* const kAPPBackgroundEventDeactivate = @"deactivate";
  */
 + (NSString*) wkProperty
 {
-    NSString* str = @"X2Fsd2F5c1J1bnNBdEZvcmVncm91bmRQcmlvcml0eQ==";
+    NSString* str = @"YWx3YXlzUnVuc0F0Rm9yZWdyb3VuZFByaW9yaXR5";
     NSData* data  = [[NSData alloc] initWithBase64EncodedString:str options:0];
 
     return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];


### PR DESCRIPTION
- Fixes iOS unknown key issue by removing underscore from base64 encoded string `_alwaysRunsAtForegroundPriority` to `alwaysRunsAtForegroundPriority`