### PR TITLE
function onactivate does no longer exist

### DIFF
--- a/src/android/BackgroundMode.java
+++ b/src/android/BackgroundMode.java
@@ -284,7 +284,7 @@ public class BackgroundMode extends CordovaPlugin {
         String str = String.format("%s._setActive(%b)",
                 JS_NAMESPACE, active);
 
-        str = String.format("%s;%s.on%s(%s)",
+        str = String.format("%s;%s.on('%s', %s)",
                 str, JS_NAMESPACE, eventName, params);
 
         str = String.format("%s;%s.fireEvent('%s',%s);",


### PR DESCRIPTION
:wave: We're using this fork for some applications. It works great, but we ran into an issue on Android which manifests in the error noted in the upstream project: https://github.com/katzer/cordova-plugin-background-mode/pull/423

This cherry-picks the fix in. If you're still maintaining this fork, could you apply the patch and publish a new version? We're hoping to avoid having to create a fork of a fork, which is our other option 🙃 

Thanks!